### PR TITLE
Apply styles for screens under 1023

### DIFF
--- a/src/data/homeSections.tsx
+++ b/src/data/homeSections.tsx
@@ -327,7 +327,7 @@ export const homeSections: HomeSection[] = [
         header: (
             <>
                 <span style={{ color: "#05aae9" }}>Actionable</span> insights.
-                <br />
+                <span className="lg:hidden"><br /></span>
                 Smarter <span style={{ color: "#05aae9" }}>staffing</span>.
                 <br />
                 <span style={{ color: "#05aae9" }}>Safer</span> residents.


### PR DESCRIPTION
Conditionally hide a `<br />` tag on large screens to improve responsive layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb5c7d41-98a1-4b07-88d0-f14215568d0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eb5c7d41-98a1-4b07-88d0-f14215568d0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

